### PR TITLE
Add source personio - stream employees

### DIFF
--- a/airbyte-integrations/connectors/source-personio/.dockerignore
+++ b/airbyte-integrations/connectors/source-personio/.dockerignore
@@ -1,0 +1,6 @@
+*
+!Dockerfile
+!main.py
+!source_personio
+!setup.py
+!secrets

--- a/airbyte-integrations/connectors/source-personio/Dockerfile
+++ b/airbyte-integrations/connectors/source-personio/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.9.13-alpine3.15 as base
+
+# build and load all requirements
+FROM base as builder
+WORKDIR /airbyte/integration_code
+
+# upgrade pip to the latest version
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base
+
+
+COPY setup.py ./
+# install necessary packages to a temporary folder
+RUN pip install --prefix=/install .
+
+# build a clean environment
+FROM base
+WORKDIR /airbyte/integration_code
+
+# copy all loaded and built libraries to a pure basic image
+COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
+
+# bash is installed for more convenient debugging.
+RUN apk --no-cache add bash
+
+# copy payload code only
+COPY main.py ./
+COPY source_personio ./source_personio
+
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+
+LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.name=airbyte/source-personio

--- a/airbyte-integrations/connectors/source-personio/README.md
+++ b/airbyte-integrations/connectors/source-personio/README.md
@@ -1,0 +1,132 @@
+# Personio Source
+
+This is the repository for the Personio source connector, written in Python.
+For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.com/integrations/sources/personio).
+
+## Local development
+
+### Prerequisites
+**To iterate on this connector, make sure to complete this prerequisites section.**
+
+#### Minimum Python version required `= 3.9.0`
+
+#### Build & Activate Virtual Environment and install dependencies
+From this connector directory, create a virtual environment:
+```
+python -m venv .venv
+```
+
+This will generate a virtualenv for this module in `.venv/`. Make sure this venv is active in your
+development environment of choice. To activate it from the terminal, run:
+```
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install '.[tests]'
+```
+If you are in an IDE, follow your IDE's instructions to activate the virtualenv.
+
+Note that while we are installing dependencies from `requirements.txt`, you should only edit `setup.py` for your dependencies. `requirements.txt` is
+used for editable installs (`pip install -e`) to pull in Python dependencies from the monorepo and will call `setup.py`.
+If this is mumbo jumbo to you, don't worry about it, just put your deps in `setup.py` but install using `pip install -r requirements.txt` and everything
+should work as you expect.
+
+#### Building via Gradle
+You can also build the connector in Gradle. This is typically used in CI and not needed for your development workflow.
+
+To build using Gradle, from the Airbyte repository root, run:
+```
+./gradlew :airbyte-integrations:connectors:source-personio:build
+```
+
+#### Create credentials
+**If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/personio)
+to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_personio/spec.yaml` file.
+Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
+See `integration_tests/sample_config.json` for a sample config file.
+
+**If you are an Airbyte core member**, copy the credentials in Lastpass under the secret name `source personio test creds`
+and place them into `secrets/config.json`.
+
+### Locally running the connector
+```
+python main.py spec
+python main.py check --config secrets/config.json
+python main.py discover --config secrets/config.json
+python main.py read --config secrets/config.json --catalog integration_tests/configured_catalog.json
+```
+
+### Locally running the connector docker image
+
+#### Build
+First, make sure you build the latest Docker image:
+```
+docker build . -t airbyte/source-personio:dev
+```
+
+You can also build the connector image via Gradle:
+```
+./gradlew :airbyte-integrations:connectors:source-personio:airbyteDocker
+```
+When building via Gradle, the docker image name and tag, respectively, are the values of the `io.airbyte.name` and `io.airbyte.version` `LABEL`s in
+the Dockerfile.
+
+#### Run
+Then run any of the connector commands as follows:
+```
+docker run --rm airbyte/source-personio:dev spec
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-personio:dev check --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-personio:dev discover --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-personio:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
+```
+## Testing
+Make sure to familiarize yourself with [pytest test discovery](https://docs.pytest.org/en/latest/goodpractices.html#test-discovery) to know how your test files and methods should be named.
+First install test dependencies into your virtual environment:
+```
+pip install .[tests]
+```
+### Unit Tests
+To run unit tests locally, from the connector directory run:
+```
+python -m pytest unit_tests
+```
+
+### Integration Tests
+There are two types of integration tests: Acceptance Tests (Airbyte's test suite for all source connectors) and custom integration tests (which are specific to this connector).
+#### Custom Integration tests
+Place custom tests inside `integration_tests/` folder, then, from the connector root, run
+```
+python -m pytest integration_tests
+```
+#### Acceptance Tests
+Customize `acceptance-test-config.yml` file to configure tests. See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference) for more information.
+If your connector requires to create or destroy resources for use during acceptance tests create fixtures for it and place them inside integration_tests/acceptance.py.
+To run your integration tests with acceptance tests, from the connector root, run
+```
+python -m pytest integration_tests -p integration_tests.acceptance
+```
+To run your integration tests with docker
+
+### Using gradle to run tests
+All commands should be run from airbyte project root.
+To run unit tests:
+```
+./gradlew :airbyte-integrations:connectors:source-personio:unitTest
+```
+To run acceptance and custom integration tests:
+```
+./gradlew :airbyte-integrations:connectors:source-personio:integrationTest
+```
+
+## Dependency Management
+All of your dependencies should go in `setup.py`, NOT `requirements.txt`. The requirements file is only used to connect internal Airbyte dependencies in the monorepo for local development.
+We split dependencies between two groups, dependencies that are:
+* required for your connector to work need to go to `MAIN_REQUIREMENTS` list.
+* required for the testing need to go to `TEST_REQUIREMENTS` list
+
+### Publishing a new version of the connector
+You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
+1. Make sure your changes are passing unit and integration tests.
+1. Bump the connector version in `Dockerfile` -- just increment the value of the `LABEL io.airbyte.version` appropriately (we use [SemVer](https://semver.org/)).
+1. Create a Pull Request.
+1. Pat yourself on the back for being an awesome contributor.
+1. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master.

--- a/airbyte-integrations/connectors/source-personio/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-personio/acceptance-test-config.yml
@@ -19,20 +19,8 @@ acceptance_tests:
       - config_path: "secrets/config.json"
         configured_catalog_path: "integration_tests/configured_catalog.json"
         empty_streams: []
-# TODO uncomment this block to specify that the tests should assert the connector outputs the records provided in the input file a file
-#        expect_records:
-#          path: "integration_tests/expected_records.jsonl"
-#          extra_fields: no
-#          exact_order: no
-#          extra_records: yes
   incremental: 
     bypass_reason: "This connector does not implement incremental sync"
-# TODO uncomment this block this block if your connector implements incremental sync: 
-#    tests:
-#      - config_path: "secrets/config.json"
-#        configured_catalog_path: "integration_tests/configured_catalog.json"
-#        future_state:
-#          future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-personio/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-personio/acceptance-test-config.yml
@@ -1,0 +1,39 @@
+# See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference)
+# for more information about how to configure these tests
+connector_image: airbyte/source-personio:dev
+acceptance_tests:
+  spec:
+    tests:
+      - spec_path: "source_personio/spec.yaml"
+  connection:
+    tests:
+      - config_path: "secrets/config.json"
+        status: "succeed"
+      - config_path: "integration_tests/invalid_config.json"
+        status: "failed"
+  discovery:
+    tests:
+      - config_path: "secrets/config.json"
+  basic_read:
+    tests:
+      - config_path: "secrets/config.json"
+        configured_catalog_path: "integration_tests/configured_catalog.json"
+        empty_streams: []
+# TODO uncomment this block to specify that the tests should assert the connector outputs the records provided in the input file a file
+#        expect_records:
+#          path: "integration_tests/expected_records.jsonl"
+#          extra_fields: no
+#          exact_order: no
+#          extra_records: yes
+  incremental: 
+    bypass_reason: "This connector does not implement incremental sync"
+# TODO uncomment this block this block if your connector implements incremental sync: 
+#    tests:
+#      - config_path: "secrets/config.json"
+#        configured_catalog_path: "integration_tests/configured_catalog.json"
+#        future_state:
+#          future_state_path: "integration_tests/abnormal_state.json"
+  full_refresh:
+    tests:
+      - config_path: "secrets/config.json"
+        configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-personio/acceptance-test-docker.sh
+++ b/airbyte-integrations/connectors/source-personio/acceptance-test-docker.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+# Build latest connector image
+docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2-)
+
+# Pull latest acctest image
+docker pull airbyte/connector-acceptance-test:latest
+
+# Run
+docker run --rm -it \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /tmp:/tmp \
+    -v $(pwd):/test_input \
+    airbyte/connector-acceptance-test \
+    --acceptance-test-config /test_input
+

--- a/airbyte-integrations/connectors/source-personio/build.gradle
+++ b/airbyte-integrations/connectors/source-personio/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'airbyte-python'
+    id 'airbyte-docker'
+    id 'airbyte-connector-acceptance-test'
+}
+
+airbytePython {
+    moduleDirectory 'source_personio'
+}

--- a/airbyte-integrations/connectors/source-personio/integration_tests/__init__.py
+++ b/airbyte-integrations/connectors/source-personio/integration_tests/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-integrations/connectors/source-personio/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-personio/integration_tests/acceptance.py
@@ -11,6 +11,4 @@ pytest_plugins = ("connector_acceptance_test.plugin",)
 @pytest.fixture(scope="session", autouse=True)
 def connector_setup():
     """This fixture is a placeholder for external resources that acceptance test might require."""
-    # TODO: setup test dependencies if needed. otherwise remove the TODO comments
     yield
-    # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-personio/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-personio/integration_tests/acceptance.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+import pytest
+
+pytest_plugins = ("connector_acceptance_test.plugin",)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def connector_setup():
+    """This fixture is a placeholder for external resources that acceptance test might require."""
+    # TODO: setup test dependencies if needed. otherwise remove the TODO comments
+    yield
+    # TODO: clean up test dependencies

--- a/airbyte-integrations/connectors/source-personio/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-personio/integration_tests/configured_catalog.json
@@ -1,0 +1,13 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "employees",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "append"
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-personio/integration_tests/invalid_config.json
+++ b/airbyte-integrations/connectors/source-personio/integration_tests/invalid_config.json
@@ -1,0 +1,3 @@
+{
+  "todo-wrong-field": "this should be an incomplete config file, used in standard tests"
+}

--- a/airbyte-integrations/connectors/source-personio/integration_tests/sample_config.json
+++ b/airbyte-integrations/connectors/source-personio/integration_tests/sample_config.json
@@ -1,0 +1,4 @@
+{
+  "client_id": "test_id",
+  "client_secret": "test_secret"
+}

--- a/airbyte-integrations/connectors/source-personio/main.py
+++ b/airbyte-integrations/connectors/source-personio/main.py
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+import sys
+
+from airbyte_cdk.entrypoint import launch
+from source_personio import SourcePersonio
+
+if __name__ == "__main__":
+    source = SourcePersonio()
+    launch(source, sys.argv[1:])

--- a/airbyte-integrations/connectors/source-personio/requirements.txt
+++ b/airbyte-integrations/connectors/source-personio/requirements.txt
@@ -1,0 +1,2 @@
+-e ../../bases/connector-acceptance-test
+-e .

--- a/airbyte-integrations/connectors/source-personio/sample_files/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-personio/sample_files/configured_catalog.json
@@ -1,0 +1,38 @@
+{
+    "streams": [
+        {
+            "stream": {
+                "name": "employees",
+                "json_schema": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": ["null", "integer"]
+                        },
+                        "first_name": {
+                            "type": ["null", "string"]
+                        },
+                        "last_name": {
+                            "type": ["null", "string"]
+                        },
+                        "email": {
+                            "type": ["null", "string"]
+                        },
+                        "office": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": ["null", "string"]
+                                }
+                            }
+                        }
+                    }
+                },
+                "supported_sync_modes": ["full_refresh"]
+            },
+            "sync_mode": "full_refresh",
+            "destination_sync_mode": "overwrite"
+        }
+    ]
+}

--- a/airbyte-integrations/connectors/source-personio/setup.py
+++ b/airbyte-integrations/connectors/source-personio/setup.py
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+from setuptools import find_packages, setup
+
+MAIN_REQUIREMENTS = [
+    "airbyte-cdk~=0.2",
+]
+
+TEST_REQUIREMENTS = [
+    "pytest~=6.2",
+    "pytest-mock~=3.6.1",
+    "connector-acceptance-test",
+]
+
+setup(
+    name="source_personio",
+    description="Source implementation for Personio.",
+    author="Airbyte",
+    author_email="contact@airbyte.io",
+    packages=find_packages(),
+    install_requires=MAIN_REQUIREMENTS,
+    package_data={"": ["*.json", "*.yaml", "schemas/*.json", "schemas/shared/*.json"]},
+    extras_require={
+        "tests": TEST_REQUIREMENTS,
+    },
+)

--- a/airbyte-integrations/connectors/source-personio/source_personio/__init__.py
+++ b/airbyte-integrations/connectors/source-personio/source_personio/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+from .source import SourcePersonio
+
+__all__ = ["SourcePersonio"]

--- a/airbyte-integrations/connectors/source-personio/source_personio/auth.py
+++ b/airbyte-integrations/connectors/source-personio/source_personio/auth.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+from typing import Any, Mapping
+
+import requests
+from airbyte_cdk.sources.streams.http.requests_native_auth import (
+    TokenAuthenticator
+)
+
+
+class PersonioOAuth(TokenAuthenticator):
+    def __init__(
+        self,
+        config,
+        token_refresh_endpoint: str,
+    ):
+        self._config = config
+        self._token_refresh_endpoint = token_refresh_endpoint
+        self._client_secret = self.get_client_secret()
+        self._client_id = self.get_client_id()
+        super().__init__(
+            ""
+        )
+
+    def get_token_refresh_endpoint(self) -> str:
+        return self._token_refresh_endpoint
+
+    def get_client_id(self) -> str:
+        return self._config["client_id"]
+
+    def get_client_secret(self) -> str:
+        return self._config["client_secret"]
+
+    def build_refresh_request_headers(self) -> Mapping[str, Any]:
+        return {
+            "Content-Type": "application/json",
+        }
+
+    def build_refresh_request_body(self) -> Mapping[str, Any]:
+        return {
+            "client_id": self.get_client_id(),
+            "client_secret": self.get_client_secret(),
+        }
+
+    def get_refresh_token(self) -> Mapping[str, Any]:
+        response = requests.request(
+            method="POST",
+            url=self.get_token_refresh_endpoint(),
+            params=self.build_refresh_request_body(),
+            headers=self.build_refresh_request_headers(),
+        )
+        response.raise_for_status()
+        return response.json()["data"]["token"]
+
+    @property
+    def token(self) -> str:
+        return f"{self._auth_method} {self.get_refresh_token()}"
+
+
+class PersonioAuth:
+    def __new__(cls, config: dict) -> PersonioOAuth:
+        return PersonioOAuth(config, "https://api.personio.de/v1/auth/")

--- a/airbyte-integrations/connectors/source-personio/source_personio/schemas/employees.json
+++ b/airbyte-integrations/connectors/source-personio/source_personio/schemas/employees.json
@@ -1,0 +1,85 @@
+{
+  "type": "object",
+  "properties": {
+      "id": {
+        "type": ["null", "integer"]
+      },
+      "first_name": {
+        "type": ["null", "string"]
+      },
+      "last_name": {
+        "type": ["null", "string"]
+      },
+      "email": {
+        "type": ["null", "string"]
+      },
+      "status": {
+        "type": ["null", "string"]
+      },
+      "position": {
+        "type": ["null", "string"]
+      },
+      "supervisor": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": ["null", "integer"]
+          },
+          "first_name": {
+            "type": ["null", "string"]
+          },
+          "last_name": {
+            "type": ["null", "string"]
+          },
+          "email": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "created_at": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "last_modified_at": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "office": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "department": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "team": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "dynamic_5333434": {
+        "title": "experience_level",
+        "type": ["null", "string"]
+      }
+  }
+}

--- a/airbyte-integrations/connectors/source-personio/source_personio/schemas/employees.json
+++ b/airbyte-integrations/connectors/source-personio/source_personio/schemas/employees.json
@@ -76,10 +76,6 @@
             "type": ["null", "string"]
           }
         }
-      },
-      "dynamic_5333434": {
-        "title": "experience_level",
-        "type": ["null", "string"]
       }
   }
 }

--- a/airbyte-integrations/connectors/source-personio/source_personio/source.py
+++ b/airbyte-integrations/connectors/source-personio/source_personio/source.py
@@ -1,0 +1,117 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+from abc import ABC
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+
+import requests
+from airbyte_cdk.sources import AbstractSource
+from airbyte_cdk.sources.streams import Stream
+from airbyte_cdk.sources.streams.http import HttpStream
+from source_personio.auth import PersonioAuth
+
+
+# Full refresh stream
+class PersonioStream(HttpStream, ABC):
+    url_base = "https://api.personio.de/v1/"
+
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        """
+        Return None when not using pagination
+
+        :param response: the most recent response from the API
+        :return If there is another page in the result, a mapping (e.g: dict) containing information needed to query the next page in the response.
+                If there are no more pages in the result, return None.
+        """
+        return None
+
+    def request_params(
+        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, any] = None, next_page_token: Mapping[str, Any] = None
+    ) -> MutableMapping[str, Any]:
+        """
+        https://developer.personio.de/reference/include-our-headers-in-your-requests
+        """
+        return {
+            "X-Personio-App-ID": "AIRBYTE"
+        }
+
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        """
+        Example attributes response:
+        "id": {
+            "label": "ID",
+            "value": 1,
+            "type": "integer",
+            "universal_id": "id"
+        },
+        "supervisor": {
+            "label": "Supervisor",
+            "value": {
+              "type": "Employee",
+              "attributes": {
+                "id": {
+                  "label": "ID",
+                  "value": 1,
+                  "type": "integer",
+                  "universal_id": "id"
+                }
+              }
+            },
+            "type": "standard",
+            "universal_id": "supervisor"
+        }
+        :return an iterable containing each record in the response
+        """
+        response_data = response.json().get("data")
+        for data in response_data:
+            attributes = data.get("attributes", {})
+            response = {}
+            for attribute, value in attributes.items():
+                # Only retrieves values which are defined in the schema
+                if attribute in self.get_json_schema().get("properties"):
+                    response[attribute] = value.get("value")
+                    if (
+                        isinstance(response[attribute], dict)
+                    ):
+                        sub_attributes = response[attribute].get("attributes", {})
+                        for sub_attribute, sub_value in sub_attributes.items():
+                            if isinstance(sub_value, dict):
+                                sub_attributes[sub_attribute] = sub_value.get("value")
+                        response[attribute] = sub_attributes
+            yield response
+
+
+class Employees(PersonioStream):
+    cursor_field = "updated_since"
+    primary_key = "id"
+
+    def path(self, **kwargs) -> str:
+        return "company/employees"
+
+
+# Source
+class SourcePersonio(AbstractSource):
+    def check_connection(self, logger, config) -> Tuple[bool, any]:
+        """
+        Check connection to Personio API.
+
+        :param config:  the user-input config object conforming to the connector's spec.yaml
+        :param logger:  logger object
+        :return Tuple[bool, any]: (True, None) if the input config can be used to connect to the API successfully, (False, error) otherwise.
+        """
+        try:
+            _ = PersonioAuth(config)
+            return True, None
+        except Exception as e:
+            return False, str(e)
+
+    def streams(self, config: Mapping[str, Any]) -> List[Stream]:
+        """
+        Get stream from Personio API.
+
+        :param config: A Mapping of the user input configuration as defined in the connector spec.
+        """
+        auth = PersonioAuth(config)
+        return [Employees(authenticator=auth)]

--- a/airbyte-integrations/connectors/source-personio/source_personio/source.py
+++ b/airbyte-integrations/connectors/source-personio/source_personio/source.py
@@ -84,7 +84,7 @@ class PersonioStream(HttpStream, ABC):
 
 
 class Employees(PersonioStream):
-    cursor_field = "updated_since"
+    cursor_field = "last_modified_at"
     primary_key = "id"
 
     def path(self, **kwargs) -> str:

--- a/airbyte-integrations/connectors/source-personio/source_personio/spec.yaml
+++ b/airbyte-integrations/connectors/source-personio/source_personio/spec.yaml
@@ -1,0 +1,17 @@
+documentationUrl: https://docs.airbyte.io/integrations/sources/source-personio
+connectionSpecification:
+  $schema: http://json-schema.org/draft-07/schema#
+  title: Personio Spec
+  type: object
+  required:
+    - client_id
+    - client_secret
+  properties:
+    client_id:
+      type: string
+      description: Client Id to access Personio API
+      airbyte_secret: true
+    client_secret:
+      type: string
+      description: Client Secret to access Personio API
+      airbyte_secret: true

--- a/airbyte-integrations/connectors/source-personio/unit_tests/__init__.py
+++ b/airbyte-integrations/connectors/source-personio/unit_tests/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-integrations/connectors/source-personio/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-personio/unit_tests/conftest.py
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+import pytest
+
+
+@pytest.fixture
+def fake_employees_response():
+    return {
+        "data": [
+            {
+                "attributes": {
+                    "id": {
+                        "label": "ID",
+                        "value": 1,
+                        "type": "integer",
+                        "universal_id": "id"
+                    },
+                    "supervisor": {
+                        "label": "Supervisor",
+                        "value": {
+                            "type": "Employee",
+                            "attributes": {
+                                "id": {
+                                    "label": "ID",
+                                    "value": 1,
+                                    "type": "integer",
+                                    "universal_id": "id"
+                                }
+                            }
+                        },
+                        "type": "standard",
+                        "universal_id": "supervisor"
+                    }
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def fake_parsed_employees():
+    return [
+        {
+            "id": 1,
+            "supervisor": {
+                "id": 1
+            }
+        }
+    ]

--- a/airbyte-integrations/connectors/source-personio/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-personio/unit_tests/test_source.py
@@ -17,6 +17,5 @@ def test_streams(mocker):
     source = SourcePersonio()
     config_mock = MagicMock()
     streams = source.streams(config_mock)
-    # TODO: replace this with your streams number
-    expected_streams_number = 2
+    expected_streams_number = 1
     assert len(streams) == expected_streams_number

--- a/airbyte-integrations/connectors/source-personio/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-personio/unit_tests/test_source.py
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+from unittest.mock import MagicMock
+
+from source_personio.source import SourcePersonio
+
+
+def test_check_connection(mocker):
+    source = SourcePersonio()
+    logger_mock, config_mock = MagicMock(), MagicMock()
+    assert source.check_connection(logger_mock, config_mock) == (True, None)
+
+
+def test_streams(mocker):
+    source = SourcePersonio()
+    config_mock = MagicMock()
+    streams = source.streams(config_mock)
+    # TODO: replace this with your streams number
+    expected_streams_number = 2
+    assert len(streams) == expected_streams_number

--- a/airbyte-integrations/connectors/source-personio/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-personio/unit_tests/test_streams.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from source_personio.source import PersonioStream, Employees
+
+
+@pytest.fixture
+def patch_base_class(mocker):
+    mocker.patch.object(PersonioStream, "path", "company/employees")
+    mocker.patch.object(PersonioStream, "primary_key", "id")
+    mocker.patch.object(PersonioStream, "__abstractmethods__", set())
+
+
+def test_request_params(patch_base_class):
+    stream = PersonioStream()
+    inputs = {"stream_slice": None, "stream_state": None, "next_page_token": None}
+    expected_params = {"X-Personio-App-ID": "AIRBYTE"}
+
+    assert stream.request_params(**inputs) == expected_params
+
+
+def test_next_page_token(patch_base_class):
+    stream = PersonioStream()
+    inputs = {"response": MagicMock()}
+    expected_token = None
+
+    assert stream.next_page_token(**inputs) == expected_token
+
+
+def test_parse_response(patch_base_class, fake_employees_response, fake_parsed_employees, requests_mock):
+    stream = Employees()
+
+    requests_mock.get('http://test.com', status_code=200, json=fake_employees_response)
+
+    assert list(stream.parse_response(requests.get('http://test.com'))) == fake_parsed_employees
+
+
+def test_request_headers(patch_base_class):
+    stream = PersonioStream()
+    inputs = {"stream_slice": None, "stream_state": None, "next_page_token": None}
+    expected_headers = {}
+
+    assert stream.request_headers(**inputs) == expected_headers
+
+
+def test_http_method(patch_base_class):
+    stream = PersonioStream()
+    expected_method = "GET"
+
+    assert stream.http_method == expected_method
+
+
+@pytest.mark.parametrize(
+    ("http_status", "should_retry"),
+    [
+        (HTTPStatus.OK, False),
+        (HTTPStatus.BAD_REQUEST, False),
+        (HTTPStatus.TOO_MANY_REQUESTS, True),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, True),
+    ],
+)
+def test_should_retry(patch_base_class, http_status, should_retry):
+    response_mock = MagicMock()
+    response_mock.status_code = http_status
+    stream = PersonioStream()
+
+    assert stream.should_retry(response_mock) == should_retry
+
+
+def test_backoff_time(patch_base_class):
+    response_mock = MagicMock()
+    stream = PersonioStream()
+    expected_backoff_time = None
+
+    assert stream.backoff_time(response_mock) == expected_backoff_time


### PR DESCRIPTION
## What
- Added source personio as a new integration connector
- Added a custom authentication for personio's specific case https://developer.personio.de/reference/post_auth-1
- Created a single "Full-refresh" stream for the endpoint company/employees https://developer.personio.de/reference/get_company-employees
- Added basic tests

## How
This connector was pre-generated using the python CDK https://docs.airbyte.com/connector-development/

## Recommended reading order
1. source_personio/spec.yml
2. source_personio/schemas
3. source_personio/auth.py
4. source_personio/source.py
Then the tests.

All of the other files were already pre-generated

## How to use it
- The image is available at the Dockerhub repository: https://hub.docker.com/repository/docker/patriciagoldbergparkdepot/airbyte_source-personio/general
- The source is already setup on Airbyte: http://localhost:8000/workspaces/12cde809-e760-4c5e-93f9-16e8776afd71/source/648e6ac0-60a2-4890-8b83-e796aba40e87
- I don't intend to use this code for now in the official Airbyte repository due to this static schema, thus this is meant to be only for this purpose: https://www.notion.so/Personio-Integration-2d4a82a410b1412cb99384f4ea7bd2e4

