### PR TITLE
PET-19560: Add attendances stream to personio

### DIFF
--- a/airbyte-integrations/connectors/source-personio/README.md
+++ b/airbyte-integrations/connectors/source-personio/README.md
@@ -30,14 +30,6 @@ used for editable installs (`pip install -e`) to pull in Python dependencies fro
 If this is mumbo jumbo to you, don't worry about it, just put your deps in `setup.py` but install using `pip install -r requirements.txt` and everything
 should work as you expect.
 
-#### Building via Gradle
-You can also build the connector in Gradle. This is typically used in CI and not needed for your development workflow.
-
-To build using Gradle, from the Airbyte repository root, run:
-```
-./gradlew :airbyte-integrations:connectors:source-personio:build
-```
-
 #### Create credentials
 **If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/personio)
 to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_personio/spec.yaml` file.
@@ -62,13 +54,6 @@ First, make sure you build the latest Docker image:
 ```
 docker build . -t airbyte/source-personio:dev
 ```
-
-You can also build the connector image via Gradle:
-```
-./gradlew :airbyte-integrations:connectors:source-personio:airbyteDocker
-```
-When building via Gradle, the docker image name and tag, respectively, are the values of the `io.airbyte.name` and `io.airbyte.version` `LABEL`s in
-the Dockerfile.
 
 #### Run
 Then run any of the connector commands as follows:
@@ -105,17 +90,6 @@ To run your integration tests with acceptance tests, from the connector root, ru
 python -m pytest integration_tests -p integration_tests.acceptance
 ```
 To run your integration tests with docker
-
-### Using gradle to run tests
-All commands should be run from airbyte project root.
-To run unit tests:
-```
-./gradlew :airbyte-integrations:connectors:source-personio:unitTest
-```
-To run acceptance and custom integration tests:
-```
-./gradlew :airbyte-integrations:connectors:source-personio:integrationTest
-```
 
 ## Dependency Management
 All of your dependencies should go in `setup.py`, NOT `requirements.txt`. The requirements file is only used to connect internal Airbyte dependencies in the monorepo for local development.

--- a/airbyte-integrations/connectors/source-personio/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-personio/integration_tests/configured_catalog.json
@@ -47,6 +47,29 @@
         ]
       },
       "sync_mode": "full_refresh"
+    },
+    {
+      "cursor_field": null,
+      "destination_sync_mode": "append",
+      "primary_key": null,
+      "stream": {
+        "default_cursor_field": [
+          "updated_at"
+        ],
+        "json_schema": {},
+        "name": "attendances",
+        "namespace": null,
+        "source_defined_cursor": true,
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ],
+        "supported_sync_modes": [
+          "full_refresh"
+        ]
+      },
+      "sync_mode": "full_refresh"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-personio/source_personio/schemas/attendances.json
+++ b/airbyte-integrations/connectors/source-personio/source_personio/schemas/attendances.json
@@ -1,0 +1,53 @@
+
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string"
+      },
+      "employee": {
+        "type": "integer"
+      },
+      "date": {
+        "type": "string",
+        "format": "date"
+      },
+      "start_time": {
+        "type": "string"
+      },
+      "end_time": {
+        "type": "string"
+      },
+      "break": {
+        "type": "integer"
+      },
+      "comment": {
+        "type": "string"
+      },
+      "updated_at": {
+        "type": "string",
+        "airbyte_type": "timestamp_with_timezone",
+        "format": "date-time"
+      },
+      "status": {
+        "type": "string"
+      },
+      "project": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "is_holiday": {
+        "type": "boolean"
+      },
+      "is_on_time_off": {
+        "type": "boolean"
+      }
+    },
+    "type": "object"
+}
+  

--- a/airbyte-integrations/connectors/source-personio/source_personio/source.py
+++ b/airbyte-integrations/connectors/source-personio/source_personio/source.py
@@ -18,7 +18,6 @@ from source_personio.auth import PersonioAuth
 class PersonioStream(HttpStream, ABC):
     url_base = "https://api.personio.de/v1/"
     limit = 200
-    data_field = None
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         """

--- a/airbyte-integrations/connectors/source-personio/source_personio/source.py
+++ b/airbyte-integrations/connectors/source-personio/source_personio/source.py
@@ -5,6 +5,7 @@
 
 from abc import ABC
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+from datetime import datetime
 
 import requests
 from airbyte_cdk.sources import AbstractSource
@@ -16,6 +17,8 @@ from source_personio.auth import PersonioAuth
 # Full refresh stream
 class PersonioStream(HttpStream, ABC):
     url_base = "https://api.personio.de/v1/"
+    limit = 200
+    data_field = None
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         """
@@ -112,6 +115,62 @@ class Attributes(PersonioStream):
             yield data
 
 
+class Attendances(PersonioStream):
+    cursor_field = "updated_at"
+    primary_key = "id"
+    offset = 0
+
+    def path(self, **kwargs) -> str:
+        return "company/attendances"
+    
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        stream_data = response.json().get("data")
+        if len(stream_data) < self.limit:
+            return
+        self.offset += self.limit
+        return {"offset": self.offset}
+
+    def request_params(
+        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, any] = None, next_page_token: Mapping[str, Any] = None
+    ) -> MutableMapping[str, Any]:
+        params = super().request_params(
+            stream_state=stream_state,
+            stream_slice=stream_slice,
+            next_page_token=next_page_token,
+        )
+        params["start_date"] = "2019-01-01"
+        params["end_date"] = datetime.today().strftime('%Y-%m-%d')
+        params["limit"] = self.limit
+        if next_page_token:
+            params.update(**next_page_token)
+        return params
+
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        """
+        Example attributes response:
+        {
+            'id': 1111111,
+            'type': 'AttendancePeriod',
+            'attributes': {
+                'employee': 22222,
+                'date': '2022-07-14',
+                'start_time': '12:30',
+                'end_time': '17:00'
+            }
+        }
+        :return an iterable containing each record in the response
+        """
+        response_data = response.json().get("data")
+        for data in response_data:
+            response = {}
+            response["id"] = data.get("id")
+            response["type"] = data.get("type")
+            attributes = data.get("attributes", {})
+            for attribute, value in attributes.items():
+                response[attribute] = value
+            yield response
+
+
 class SourcePersonio(AbstractSource):
     def check_connection(self, logger, config) -> Tuple[bool, any]:
         """
@@ -134,4 +193,8 @@ class SourcePersonio(AbstractSource):
         :param config: A Mapping of the user input configuration as defined in the connector spec.
         """
         auth = PersonioAuth(config)
-        return [Attributes(authenticator=auth), Employees(authenticator=auth)]
+        return [
+            Attributes(authenticator=auth),
+            Employees(authenticator=auth),
+            Attendances(authenticator=auth),
+        ]


### PR DESCRIPTION
Add the attendance stream to the personio source (https://developer.personio.de/reference/get_company-attendances).

There are two mandatory parameters (`start_date` and `end_date`), thus adding it to the parameter request.
The parameter `limit` must also be `>1`, thus adding an offset pagination.
Removed from the README everything related to the `gradlew` execution, as it doesn't work