### PR TITLE
PET-19523: Add incremental dependency to GitLab jobs

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/README.md
+++ b/airbyte-integrations/connectors/source-gitlab/README.md
@@ -7,7 +7,7 @@ For information about how to use this connector within Airbyte, see [the documen
 
 ### Prerequisites
 
-- Python (~=3.9)
+- Python (>=3.10)
 - Poetry (~=1.7) - installation instructions [here](https://python-poetry.org/docs/#installation)
 
 ### Installing the connector
@@ -21,7 +21,7 @@ poetry install --with dev
 ### Create credentials
 
 **If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/gitlab)
-to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_gitlab/spec.yaml` file.
+to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_gitlab/spec.json` file.
 Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
 See `sample_files/sample_config.json` for a sample config file.
 

--- a/airbyte-integrations/connectors/source-gitlab/source_gitlab/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/source_gitlab/manifest.yaml
@@ -170,7 +170,7 @@ definitions:
     $ref: "#/definitions/base_projects_child_stream"
     incremental_sync:
       type: DatetimeBasedCursor
-      cursor_field: "{{ parameters.get('cursor_field', 'updated_at') }}"
+      cursor_field: "{{ parameters.get('cursor_field', 'updated_at') + duration('PT1S') }}"
       start_datetime: "{{ config.get('start_date', '2014-01-01T00:00:00Z') }}"
       datetime_format: "%Y-%m-%dT%H:%M:%SZ"
       cursor_datetime_formats:

--- a/airbyte-integrations/connectors/source-gitlab/source_gitlab/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/source_gitlab/manifest.yaml
@@ -471,8 +471,23 @@ definitions:
 
   jobs_stream:
     name: "jobs"
-    $ref: "#/definitions/base_projects_child_stream"
-    retriever: "#/definitions/pipelines_child_streams_retriever"
+    $ref: "#/definitions/base_projects_incremental_child_stream"
+    retriever:
+      type: SimpleRetriever
+      record_selector: "#/definitions/selector"
+      paginator: "#/definitions/paginator"
+      requester:
+        $ref: '#/definitions/requester'
+        path: 'projects/{{ stream_slice.parent_slice.id }}/pipelines/{{ stream_slice.pipeline_id }}/jobs'
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            stream: "#/definitions/pipelines_stream"
+            parent_key: id
+            partition_field: pipeline_id
+            parent_stream_name: pipelines
+            incremental_dependency: true
     transformations:
       - type: AddFields
         fields:
@@ -491,6 +506,10 @@ definitions:
           - type: AddedFieldDefinition
             path: ["commit_id"]
             value: "{{ (record.get('commit') or {}).get('id') }}"
+          - type: AddedFieldDefinition
+            path:
+              - updated_at
+            value: "{{ (record.get('pipeline') or {}).get('updated_at') }}"
     $parameters:
       path: "projects/{{ stream_slice.parent_slice.id }}/pipelines/{{ stream_slice.id }}/jobs"
 

--- a/airbyte-integrations/connectors/source-gitlab/source_gitlab/schemas/jobs.json
+++ b/airbyte-integrations/connectors/source-gitlab/source_gitlab/schemas/jobs.json
@@ -136,6 +136,11 @@
           "type": ["null", "boolean"]
         }
       }
+    },
+    "updated_at": {
+      "description": "Date and time of last update",
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }


### PR DESCRIPTION
## What
- Add incremental_dependency to jobs stream

## How
- Add the field `updated_at` from pipelines to `jobs`
- Used the field `updated_at` from pipelines to filter the `jobs`

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
