### PR TITLE
PET-23824: Add available vacation balance stream

### DIFF
--- a/airbyte-integrations/connectors/source-personio/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-personio/integration_tests/configured_catalog.json
@@ -78,6 +78,29 @@
           "updated_at"
         ],
         "json_schema": {},
+        "name": "absences",
+        "namespace": null,
+        "source_defined_cursor": true,
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ],
+        "supported_sync_modes": [
+          "full_refresh"
+        ]
+      },
+      "sync_mode": "full_refresh"
+    },
+    {
+      "cursor_field": null,
+      "destination_sync_mode": "overwrite",
+      "primary_key": null,
+      "stream": {
+        "default_cursor_field": [
+          "updated_at"
+        ],
+        "json_schema": {},
         "name": "absence_balance_employees",
         "namespace": null,
         "source_defined_cursor": true,

--- a/airbyte-integrations/connectors/source-personio/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-personio/integration_tests/configured_catalog.json
@@ -78,7 +78,7 @@
           "updated_at"
         ],
         "json_schema": {},
-        "name": "absences",
+        "name": "absence_balance_employees",
         "namespace": null,
         "source_defined_cursor": true,
         "source_defined_primary_key": [

--- a/airbyte-integrations/connectors/source-personio/source_personio/auth.py
+++ b/airbyte-integrations/connectors/source-personio/source_personio/auth.py
@@ -20,6 +20,7 @@ class PersonioOAuth(TokenAuthenticator):
         self._token_refresh_endpoint = token_refresh_endpoint
         self._client_secret = self.get_client_secret()
         self._client_id = self.get_client_id()
+        self._token = None
         super().__init__(
             ""
         )
@@ -52,11 +53,14 @@ class PersonioOAuth(TokenAuthenticator):
             headers=self.build_refresh_request_headers(),
         )
         response.raise_for_status()
-        return response.json()["data"]["token"]
+        self._token = response.json()["data"]["token"]
+        return self._token
 
     @property
     def token(self) -> str:
-        return f"{self._auth_method} {self.get_refresh_token()}"
+        if not self._token:
+            return f"{self._auth_method} {self.get_refresh_token()}"
+        return f"{self._auth_method} {self._token}"
 
 
 class PersonioAuth:

--- a/airbyte-integrations/connectors/source-personio/source_personio/schemas/absence_balance_employees.json
+++ b/airbyte-integrations/connectors/source-personio/source_personio/schemas/absence_balance_employees.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    },
+    "balance": {
+      "type": "number"
+    },
+    "available_balance": {
+      "type": "number"
+    },
+    "parent_id": {
+      "type": "integer"
+    }
+  },
+  "type": "object"
+}

--- a/airbyte-integrations/connectors/source-personio/source_personio/source.py
+++ b/airbyte-integrations/connectors/source-personio/source_personio/source.py
@@ -4,7 +4,9 @@
 
 
 from abc import ABC
-from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
+from urllib.parse import urlparse
+from airbyte_cdk.models import SyncMode
 from datetime import datetime
 
 import requests
@@ -15,7 +17,11 @@ from source_personio.auth import PersonioAuth
 
 
 # Full refresh stream
-class PersonioStream(HttpStream, ABC):
+
+class PersonioBaseStream(HttpStream, ABC):
+    """
+    Base class for Personio API streams.
+    """
     url_base = "https://api.personio.de/v1/"
     limit = 200
 
@@ -39,6 +45,8 @@ class PersonioStream(HttpStream, ABC):
             "X-Personio-App-ID": "AIRBYTE"
         }
 
+
+class PersonioStream(PersonioBaseStream):
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         """
         Example attributes response:
@@ -83,12 +91,56 @@ class PersonioStream(HttpStream, ABC):
             yield response
 
 
+class PersonioSubStream(PersonioBaseStream):
+    def __init__(self, name: str, path: str, parent_stream: Stream, **kwargs: Any) -> None:
+        self._name = name
+        self._path = path
+        self._parent_stream = parent_stream
+        super().__init__(**kwargs)
+
+    def parse_response(self, response: requests.Response, stream_slice: Mapping[str, Any] = None, **kwargs) -> Iterable[Mapping]:
+        response_data = response.json().get("data")
+        parent_id = stream_slice.get("id") if stream_slice else None
+        for data in response_data:
+            data["parent_id"] = parent_id
+            yield data
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def path(
+        self,
+        *,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        stream_slice: Optional[Mapping[str, Any]] = None,
+        next_page_token: Optional[Mapping[str, Any]] = None,
+    ) -> str:
+        try:
+            return self._path.format(stream_slice=stream_slice)
+        except Exception as e:
+            raise e
+
+    def stream_slices(self, stream_state: Mapping[str, Any] = None, **kwargs) -> Iterable[Optional[Mapping[str, any]]]:
+        for _slice in self._parent_stream.stream_slices(sync_mode=SyncMode.full_refresh):
+            for parent_record in self._parent_stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=_slice):
+                yield parent_record
+
+
 class Employees(PersonioStream):
     cursor_field = "last_modified_at"
     primary_key = "id"
 
     def path(self, **kwargs) -> str:
         return "company/employees"
+
+    @property
+    def use_cache(self) -> bool:
+        return True
+
+
+class AbsenceBalanceEmployees(PersonioSubStream):
+    primary_key = "id"
 
 
 class Attributes(PersonioStream):
@@ -256,9 +308,16 @@ class SourcePersonio(AbstractSource):
         :param config: A Mapping of the user input configuration as defined in the connector spec.
         """
         auth = PersonioAuth(config)
+        employees = Employees(authenticator=auth)
         return [
             Attributes(authenticator=auth),
-            Employees(authenticator=auth),
+            employees,
             Attendances(authenticator=auth),
             Absences(authenticator=auth),
+            AbsenceBalanceEmployees(
+                name="absence_balance_employees",
+                authenticator=auth,
+                parent_stream=employees,
+                path="company/employees/{stream_slice[id]}/absences/balance"
+            ),
         ]


### PR DESCRIPTION
## What
- Added endpoint https://developer.personio.de/v1.0/reference/get_company-employees-employee-id-absences-balance
- Since this is a substream of Employees, created a new PersonioSubStream class based on the code from here https://docs.airbyte.com/connector-development/tutorials/custom-python-connector/reading-from-a-subresource
- Because this is doing many requested, adjusted the PersonioOAuth class, to cash the refresh, instead of calling the refresh token endpoint in each call

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
